### PR TITLE
Add self tests to ensure Moka can test itself

### DIFF
--- a/tests/Builder/ProxyBuilderSelfTest.php
+++ b/tests/Builder/ProxyBuilderSelfTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: angelogiuffredi
+ * Date: 14/06/2017
+ * Time: 14:12
+ */
+
+namespace Tests\Builder;
+
+
+use Moka\Builder\ProxyBuilder;
+use Moka\Exception\MockNotCreatedException;
+use Moka\Proxy\Proxy;
+use Moka\Traits\MokaCleanerTrait;
+use Moka\Traits\MokaTrait;
+use PHPUnit_Framework_MockObject_Generator as MockGenerator;
+
+class ProxyBuilderSelfTest extends \PHPUnit_Framework_TestCase
+{
+    use MokaTrait;
+    use MokaCleanerTrait;
+
+    /**
+     * @var ProxyBuilder
+     */
+    private $proxyBuilder;
+
+    public function setUp()
+    {
+        $this->proxyBuilder = new ProxyBuilder(
+            $this->mock(MockGenerator::class)->serve()
+        );
+    }
+
+    public function testGetProxySuccess()
+    {
+        $this->decorateSuccessfulMockGenerator();
+
+        $proxy1 = $this->proxyBuilder->getProxy(\stdClass::class);
+        $proxy2 = $this->proxyBuilder->getProxy(\stdClass::class);
+
+        $this->assertInstanceOf(Proxy::class, $proxy1);
+
+        $this->assertSame($proxy1, $proxy2);
+    }
+
+    public function testGetProxySuccessWithAlias()
+    {
+        $this->decorateSuccessfulMockGenerator();
+
+        $proxy1 = $this->proxyBuilder->getProxy(\stdClass::class, 'bar');
+        $proxy2 = $this->proxyBuilder->getProxy(\stdClass::class, 'foo');
+
+        $this->assertInstanceOf(Proxy::class, $proxy1);
+        $this->assertInstanceOf(Proxy::class, $proxy2);
+
+        $this->assertNotSame($proxy1, $proxy2);
+    }
+
+    public function testGetProxyThrowException()
+    {
+        $this->expectException(MockNotCreatedException::class);
+
+        $this->mock(MockGenerator::class)->stub([
+            'getMock' => new \Exception()
+        ]);
+
+        $this->proxyBuilder->getProxy(\stdClass::class, 'acme');
+    }
+
+    private function decorateSuccessfulMockGenerator()
+    {
+        $this->mock(MockGenerator::class)->stub([
+            'getMock' => $this->mock(\stdClass::class)->serve()
+        ]);
+    }
+}

--- a/tests/Builder/ProxyBuilderSelfTest.php
+++ b/tests/Builder/ProxyBuilderSelfTest.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: angelogiuffredi
- * Date: 14/06/2017
- * Time: 14:12
- */
 
 namespace Tests\Builder;
 

--- a/tests/Builder/ProxyBuilderSelfTest.php
+++ b/tests/Builder/ProxyBuilderSelfTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Builder;
 
-
 use Moka\Builder\ProxyBuilder;
 use Moka\Exception\MockNotCreatedException;
 use Moka\Proxy\Proxy;

--- a/tests/Builder/ProxyBuilderTest.php
+++ b/tests/Builder/ProxyBuilderTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Builder;
 
-
 use Moka\Builder\ProxyBuilder;
 use Moka\Exception\MockNotCreatedException;
 use Moka\Proxy\Proxy;
@@ -68,6 +67,4 @@ class ProxyBuilderTest extends \PHPUnit_Framework_TestCase
 
         $this->proxyBuilder->getProxy(\stdClass::class, 'acme');
     }
-
-
 }

--- a/tests/Builder/ProxyBuilderTest.php
+++ b/tests/Builder/ProxyBuilderTest.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: angelogiuffredi
- * Date: 14/06/2017
- * Time: 14:12
- */
 
 namespace Tests\Builder;
 

--- a/tests/Builder/ProxyBuilderTest.php
+++ b/tests/Builder/ProxyBuilderTest.php
@@ -47,7 +47,7 @@ class ProxyBuilderTest extends \PHPUnit_Framework_TestCase
         $proxy1 = $this->proxyBuilder->getProxy(\stdClass::class);
         $proxy2 = $this->proxyBuilder->getProxy(\stdClass::class);
 
-        $this->assertInstanceOf(Proxy::class, $proxy2);
+        $this->assertInstanceOf(Proxy::class, $proxy1);
 
         $this->assertSame($proxy1, $proxy2);
     }

--- a/tests/Factory/ProxyBuilderFactoryTest.php
+++ b/tests/Factory/ProxyBuilderFactoryTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Factory;
 
-
 use Moka\Builder\ProxyBuilder;
 use Moka\Factory\ProxyBuilderFactory;
 

--- a/tests/Factory/ProxyBuilderFactoryTest.php
+++ b/tests/Factory/ProxyBuilderFactoryTest.php
@@ -14,15 +14,6 @@ use Moka\Factory\ProxyBuilderFactory;
 
 class ProxyBuilderFactoryTest extends \PHPUnit_Framework_TestCase
 {
-    private $mock;
-
-    public function setUp()
-    {
-        $this->mock = $this->getMockBuilder(\stdClass::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-    }
-
     public function testGet()
     {
         $proxyBuilder1 = ProxyBuilderFactory::get();

--- a/tests/Factory/ProxyBuilderFactoryTest.php
+++ b/tests/Factory/ProxyBuilderFactoryTest.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: angelogiuffredi
- * Date: 14/06/2017
- * Time: 13:44
- */
 
 namespace Tests\Factory;
 

--- a/tests/Factory/ProxyFactorySelfTest.php
+++ b/tests/Factory/ProxyFactorySelfTest.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: angelogiuffredi
- * Date: 14/06/2017
- * Time: 13:40
- */
 
 namespace Tests\Factory;
 

--- a/tests/Factory/ProxyFactorySelfTest.php
+++ b/tests/Factory/ProxyFactorySelfTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Factory;
 
-
 use Moka\Factory\ProxyFactory;
 use Moka\Proxy\Proxy;
 use Moka\Traits\MokaCleanerTrait;

--- a/tests/Factory/ProxyFactorySelfTest.php
+++ b/tests/Factory/ProxyFactorySelfTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: angelogiuffredi
+ * Date: 14/06/2017
+ * Time: 13:40
+ */
+
+namespace Tests\Factory;
+
+
+use Moka\Factory\ProxyFactory;
+use Moka\Proxy\Proxy;
+use Moka\Traits\MokaCleanerTrait;
+use Moka\Traits\MokaTrait;
+
+class ProxyFactorySelfTest extends \PHPUnit_Framework_TestCase
+{
+    use MokaTrait;
+    use MokaCleanerTrait;
+
+    public function testGet()
+    {
+        $mock1 = ProxyFactory::get($this->mock(\stdClass::class)->serve());
+        $mock2 = ProxyFactory::get($this->mock(\stdClass::class)->serve());
+
+        $this->assertInstanceOf(Proxy::class, $mock1);
+        $this->assertInstanceOf(Proxy::class, $mock2);
+
+        $this->assertNotSame($mock1, $mock2);
+    }
+}

--- a/tests/Factory/ProxyFactoryTest.php
+++ b/tests/Factory/ProxyFactoryTest.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: angelogiuffredi
- * Date: 14/06/2017
- * Time: 13:40
- */
 
 namespace Tests\Factory;
 

--- a/tests/Factory/ProxyFactoryTest.php
+++ b/tests/Factory/ProxyFactoryTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Factory;
 
-
 use Moka\Factory\ProxyFactory;
 use Moka\Proxy\Proxy;
 

--- a/tests/MokaTest.php
+++ b/tests/MokaTest.php
@@ -2,13 +2,11 @@
 
 namespace Tests;
 
-
 use Moka\Moka;
 use Moka\Proxy\Proxy;
 
 class MokaTest extends \PHPUnit_Framework_TestCase
 {
-
     public function testGetSuccess()
     {
         $this->assertInstanceOf(

--- a/tests/MokaTest.php
+++ b/tests/MokaTest.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: angelogiuffredi
- * Date: 14/06/2017
- * Time: 15:02
- */
 
 namespace Tests;
 

--- a/tests/Proxy/MockFakeClass.php
+++ b/tests/Proxy/MockFakeClass.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Proxy;
 
-
 class MockFakeClass
 {
     public function isValid(): bool
@@ -12,6 +11,5 @@ class MockFakeClass
 
     public function throwException()
     {
-
     }
 }

--- a/tests/Proxy/MockFakeClass.php
+++ b/tests/Proxy/MockFakeClass.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: angelogiuffredi
- * Date: 14/06/2017
- * Time: 13:56
- */
 
 namespace Tests\Proxy;
 

--- a/tests/Proxy/ProxyContainerSelfTest.php
+++ b/tests/Proxy/ProxyContainerSelfTest.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: angelogiuffredi
- * Date: 14/06/2017
- * Time: 13:17
- */
 
 namespace Tests\Proxy;
 

--- a/tests/Proxy/ProxyContainerSelfTest.php
+++ b/tests/Proxy/ProxyContainerSelfTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Proxy;
 
-
 use Moka\Exception\InvalidIdentifierException;
 use Moka\Proxy\Proxy;
 use Moka\Proxy\ProxyContainer;

--- a/tests/Proxy/ProxyContainerSelfTest.php
+++ b/tests/Proxy/ProxyContainerSelfTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: angelogiuffredi
+ * Date: 14/06/2017
+ * Time: 13:17
+ */
+
+namespace Tests\Proxy;
+
+
+use Moka\Exception\InvalidIdentifierException;
+use Moka\Proxy\Proxy;
+use Moka\Proxy\ProxyContainer;
+use Moka\Traits\MokaCleanerTrait;
+use Moka\Traits\MokaTrait;
+
+class ProxyContainerSelfTest extends \PHPUnit_Framework_TestCase
+{
+    use MokaTrait;
+    use MokaCleanerTrait;
+
+    /**
+     * @var ProxyContainer
+     */
+    private $proxyContainer;
+
+    public function setUp()
+    {
+        $this->proxyContainer = new ProxyContainer();
+
+        $this->proxyContainer->set(
+            'foo',
+            $this->mock(Proxy::class)->serve()
+        );
+    }
+
+    public function testGetSuccess()
+    {
+        $proxy = $this->proxyContainer->get('foo');
+
+        $this->assertInstanceOf(Proxy::class, $proxy);
+    }
+
+    public function testGetFailure()
+    {
+        $this->expectException(InvalidIdentifierException::class);
+        $this->proxyContainer->get('bar');
+    }
+
+    public function testHasSuccess()
+    {
+        $this->assertTrue(
+            $this->proxyContainer->has('foo')
+        );
+    }
+
+    public function testHasFailure()
+    {
+        $this->assertFalse(
+            $this->proxyContainer->has('bar')
+        );
+    }
+
+    public function testSet()
+    {
+        $this->proxyContainer->set('acme', $this->mock(Proxy::class)->serve());
+        $this->assertInstanceOf(
+            Proxy::class,
+            $this->proxyContainer->get('acme')
+        );
+    }
+}

--- a/tests/Proxy/ProxyContainerTest.php
+++ b/tests/Proxy/ProxyContainerTest.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: angelogiuffredi
- * Date: 14/06/2017
- * Time: 13:17
- */
 
 namespace Tests\Proxy;
 

--- a/tests/Proxy/ProxyContainerTest.php
+++ b/tests/Proxy/ProxyContainerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Proxy;
 
-
 use Moka\Exception\InvalidIdentifierException;
 use Moka\Proxy\Proxy;
 use Moka\Proxy\ProxyContainer;

--- a/tests/Proxy/ProxySelfTest.php
+++ b/tests/Proxy/ProxySelfTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: angelogiuffredi
+ * Date: 14/06/2017
+ * Time: 13:48
+ */
+
+namespace Tests\Proxy;
+
+
+use Moka\Proxy\Proxy;
+use Moka\Traits\MokaCleanerTrait;
+use Moka\Traits\MokaTrait;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+class ProxySelfTest extends \PHPUnit_Framework_TestCase
+{
+    use MokaTrait;
+    use MokaCleanerTrait;
+
+    /**
+     * @var Proxy
+     */
+    private $proxy;
+
+    public function setUp()
+    {
+        $this->proxy = new Proxy(
+            $this->mock(MockFakeClass::class)->serve()
+        );
+    }
+
+    public function testServe()
+    {
+        $this->assertInstanceOf(MockObject::class, $this->proxy->serve());
+    }
+
+    public function testStubScalarValue()
+    {
+        $this->proxy->stub([
+            'isValid' => true
+        ]);
+
+        $this->assertTrue($this->proxy->serve()->isValid());
+    }
+
+    public function testStubThrowException()
+    {
+        $this->expectException(\Exception::class);
+
+        $this->proxy->stub([
+            'throwException' => new \Exception()
+        ]);
+
+        $this->proxy->serve()->throwException();
+    }
+}

--- a/tests/Proxy/ProxySelfTest.php
+++ b/tests/Proxy/ProxySelfTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Proxy;
 
-
 use Moka\Proxy\Proxy;
 use Moka\Traits\MokaCleanerTrait;
 use Moka\Traits\MokaTrait;

--- a/tests/Proxy/ProxySelfTest.php
+++ b/tests/Proxy/ProxySelfTest.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: angelogiuffredi
- * Date: 14/06/2017
- * Time: 13:48
- */
 
 namespace Tests\Proxy;
 

--- a/tests/Proxy/ProxyTest.php
+++ b/tests/Proxy/ProxyTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Proxy;
 
-
 use Moka\Proxy\Proxy;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 

--- a/tests/Proxy/ProxyTest.php
+++ b/tests/Proxy/ProxyTest.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: angelogiuffredi
- * Date: 14/06/2017
- * Time: 13:48
- */
 
 namespace Tests\Proxy;
 


### PR DESCRIPTION
We need completely new test cases (instead of just adding methods to existing ones) to avoid issues with singletons in Moka.

This also serves as a migration example from PHPUnit mocks to Moka ones.