### PR TITLE
Move the test cases to src/

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,11 @@ class YourOwnMockingStrategy extends AbstractMockingStrategy
 }
 ```
 
-**Warning:** your plugin *FQCN* must match the template `Moka\Plugin\YourOwn\YourOwnPlugin`, where `YourOwn` is the name of the plugin.
+**Warning:** your plugin *FQCN* must match the template `Moka\Plugin\YourOwn\YourOwnPlugin`, where `YourOwn` is the name of the plugin.  
+Both your plugin and your strategy must pass our test cases (please install [phpunit/phpunit](https://packagist.org/packages/phpunit/phpunit) to run them):
+
+- `MokaPluginTestCase`
+- `MokaMockingStrategyTestCase`
 
 Let [us](#credits) know of any **Moka**-related development!
 <!---

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,7 +16,7 @@
 
     <testsuites>
         <testsuite name="unit">
-            <directory>./tests/</directory>
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
 
@@ -24,8 +24,9 @@
         <whitelist>
             <directory>src</directory>
             <exclude>
-                <directory>src/Moka/Traits</directory>
                 <directory>src/Moka/Exception</directory>
+                <directory>src/Moka/Tests</directory>
+                <directory>src/Moka/Traits</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Moka/Tests/MokaMockingStrategyTestCase.php
+++ b/src/Moka/Tests/MokaMockingStrategyTestCase.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Tests\Strategy;
+namespace Moka\Tests;
 
 use Moka\Exception\InvalidArgumentException;
 use Moka\Factory\StubFactory;
@@ -13,7 +13,7 @@ use Tests\BarTestClass;
 use Tests\FooTestClass;
 use Tests\TestInterface;
 
-abstract class MockingStrategyTestCase extends TestCase
+abstract class MokaMockingStrategyTestCase extends TestCase
 {
     /**
      * @var MockingStrategyInterface

--- a/src/Moka/Tests/MokaPluginTestCase.php
+++ b/src/Moka/Tests/MokaPluginTestCase.php
@@ -19,7 +19,7 @@ abstract class MokaPluginTestCase extends TestCase
         $this->assertInstanceOf(MockingStrategyInterface::class, ($this->pluginFQCN)::getStrategy());
     }
 
-    final protected function setPluginFQCN(string $pluginFQCN): void
+    final protected function setPluginFQCN(string $pluginFQCN)
     {
         $this->pluginFQCN = $pluginFQCN;
     }

--- a/src/Moka/Tests/MokaPluginTestCase.php
+++ b/src/Moka/Tests/MokaPluginTestCase.php
@@ -1,13 +1,13 @@
 <?php
 declare(strict_types=1);
 
-namespace Tests\Plugin;
+namespace Moka\Tests;
 
 use Moka\Plugin\PluginInterface;
 use Moka\Strategy\MockingStrategyInterface;
 use PHPUnit\Framework\TestCase;
 
-class PluginTestCase extends TestCase
+abstract class MokaPluginTestCase extends TestCase
 {
     /**
      * @var PluginInterface
@@ -19,7 +19,7 @@ class PluginTestCase extends TestCase
         $this->assertInstanceOf(MockingStrategyInterface::class, ($this->pluginFQCN)::getStrategy());
     }
 
-    final protected function setPluginFQCN(string $pluginFQCN)
+    final protected function setPluginFQCN(string $pluginFQCN): void
     {
         $this->pluginFQCN = $pluginFQCN;
     }

--- a/tests/Plugin/Mockery/MockeryMockingStrategyTest.php
+++ b/tests/Plugin/Mockery/MockeryMockingStrategyTest.php
@@ -6,12 +6,12 @@ namespace Tests\Plugin\Mockery;
 use Moka\Exception\MockNotCreatedException;
 use Moka\Factory\StubFactory;
 use Moka\Plugin\Mockery\MockeryMockingStrategy;
+use Moka\Tests\MokaMockingStrategyTestCase;
 use Tests\BarTestClass;
 use Tests\FooTestClass;
-use Tests\Strategy\MockingStrategyTestCase;
 use Tests\TestInterface;
 
-class MockeryMockingStrategyTest extends MockingStrategyTestCase
+class MockeryMockingStrategyTest extends MokaMockingStrategyTestCase
 {
     public function __construct($name = null, array $data = [], $dataName = '')
     {

--- a/tests/Plugin/Mockery/MockeryPluginTest.php
+++ b/tests/Plugin/Mockery/MockeryPluginTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 namespace Tests\Plugin\Mockery;
 
 use Moka\Plugin\Mockery\MockeryPlugin;
-use Tests\Plugin\PluginTestCase;
+use Moka\Tests\MokaPluginTestCase;
 
-class MockeryPluginTest extends PluginTestCase
+class MockeryPluginTest extends MokaPluginTestCase
 {
     public function __construct($name = null, array $data = [], $dataName = '')
     {

--- a/tests/Plugin/PHPUnit/PHPUnitMockingStrategyTest.php
+++ b/tests/Plugin/PHPUnit/PHPUnitMockingStrategyTest.php
@@ -6,12 +6,12 @@ namespace Tests\Plugin\PHPUnit;
 use Moka\Exception\MockNotCreatedException;
 use Moka\Factory\StubFactory;
 use Moka\Plugin\PHPUnit\PHPUnitMockingStrategy;
+use Moka\Tests\MokaMockingStrategyTestCase;
 use Tests\BarTestClass;
 use Tests\FooTestClass;
-use Tests\Strategy\MockingStrategyTestCase;
 use Tests\TestInterface;
 
-class PHPUnitMockingStrategyTest extends MockingStrategyTestCase
+class PHPUnitMockingStrategyTest extends MokaMockingStrategyTestCase
 {
     public function __construct($name = null, array $data = [], $dataName = '')
     {

--- a/tests/Plugin/PHPUnit/PHPUnitPluginTest.php
+++ b/tests/Plugin/PHPUnit/PHPUnitPluginTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 namespace Tests\Plugin\PHPUnit;
 
 use Moka\Plugin\PHPUnit\PHPUnitPlugin;
-use Tests\Plugin\PluginTestCase;
+use Moka\Tests\MokaPluginTestCase;
 
-class PHPUnitPluginTest extends PluginTestCase
+class PHPUnitPluginTest extends MokaPluginTestCase
 {
     public function __construct($name = null, array $data = [], $dataName = '')
     {

--- a/tests/Plugin/Phake/PhakeMockingStrategyTest.php
+++ b/tests/Plugin/Phake/PhakeMockingStrategyTest.php
@@ -6,12 +6,12 @@ namespace Tests\Plugin\Phake;
 use Moka\Exception\MockNotCreatedException;
 use Moka\Factory\StubFactory;
 use Moka\Plugin\Phake\PhakeMockingStrategy;
+use Moka\Tests\MokaMockingStrategyTestCase;
 use Tests\BarTestClass;
 use Tests\FooTestClass;
-use Tests\Strategy\MockingStrategyTestCase;
 use Tests\TestInterface;
 
-class PhakeMockingStrategyTest extends MockingStrategyTestCase
+class PhakeMockingStrategyTest extends MokaMockingStrategyTestCase
 {
     public function __construct($name = null, array $data = [], $dataName = '')
     {

--- a/tests/Plugin/Phake/PhakePluginTest.php
+++ b/tests/Plugin/Phake/PhakePluginTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 namespace Tests\Plugin\Phake;
 
 use Moka\Plugin\Phake\PhakePlugin;
-use Tests\Plugin\PluginTestCase;
+use Moka\Tests\MokaPluginTestCase;
 
-class PhakePluginTest extends PluginTestCase
+class PhakePluginTest extends MokaPluginTestCase
 {
     public function __construct($name = null, array $data = [], $dataName = '')
     {

--- a/tests/Plugin/Prophecy/ProphecyMockingStrategyTest.php
+++ b/tests/Plugin/Prophecy/ProphecyMockingStrategyTest.php
@@ -6,14 +6,14 @@ namespace Tests\Plugin\Prophecy;
 use Moka\Exception\MockNotCreatedException;
 use Moka\Factory\StubFactory;
 use Moka\Plugin\Prophecy\ProphecyMockingStrategy;
+use Moka\Tests\MokaMockingStrategyTestCase;
 use Prophecy\Doubler\Doubler;
 use Prophecy\Doubler\LazyDouble;
 use Prophecy\Prophecy\ObjectProphecy;
 use Tests\FooTestClass;
-use Tests\Strategy\MockingStrategyTestCase;
 use Tests\TestInterface;
 
-class ProphecyMockingStrategyTest extends MockingStrategyTestCase
+class ProphecyMockingStrategyTest extends MokaMockingStrategyTestCase
 {
     public function __construct($name = null, array $data = [], $dataName = '')
     {

--- a/tests/Plugin/Prophecy/ProphecyPluginTest.php
+++ b/tests/Plugin/Prophecy/ProphecyPluginTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 namespace Tests\Plugin\Prophecy;
 
 use Moka\Plugin\Prophecy\ProphecyPlugin;
-use Tests\Plugin\PluginTestCase;
+use Moka\Tests\MokaPluginTestCase;
 
-class ProphecyPluginTest extends PluginTestCase
+class ProphecyPluginTest extends MokaPluginTestCase
 {
     public function __construct($name = null, array $data = [], $dataName = '')
     {


### PR DESCRIPTION
This allows plugin developers to verify their implementations against our test cases.
They depend on PHPUnit, but imho it's up to developers to install the dependency to run the tests.

@Giuffre: in case you approve the PR, would you name the namespace `Moka\Test` (singular), or `Moka\Tests` is fine in your opinion?