### PR TITLE
Use random_int instead of mt_rand.

### DIFF
--- a/src/Moka/Generator/Template/ClassTemplate.php
+++ b/src/Moka/Generator/Template/ClassTemplate.php
@@ -103,7 +103,7 @@ class ClassTemplate implements TemplateInterface
         $proxyClassName = sprintf(
             self::TEMPLATE_FQCN,
             preg_replace('/\\\/', '__', $mockClassName),
-            mt_rand()
+            random_int($min = 0, $max = PHP_INT_MAX)
         );
 
         list($callNameType, $callArgumentsType) = $callParametersTypes;


### PR DESCRIPTION
We encountered collisions in generating proxy class names by using `mt_rand`.